### PR TITLE
Updated RegEx

### DIFF
--- a/youtube.update.sh
+++ b/youtube.update.sh
@@ -35,7 +35,7 @@ if [ ! -f $dnsmasqFile ]; then
 fi
 
 cp $ytHosts $workFile
-zgrep -e "reply.*-.*\.googlevideo.*\..*\..*\..*" $piLogs \
+zgrep -E "reply.r[0-9-]-*sn-[0-9a-z]{8}.googlevideo*|reply.r[0-9-]-*sn-[0-9a-z]{12}-[0-9a-z]{4}.googlevideo*|reply.*-.*\.googlevideo.*\..*\..*\..*" $piLogs \
     | awk -v fIP=$forceIP '{ print fIP, $6 }' >> $workFile
 
 sort -u $workFile -o $workFile


### PR DESCRIPTION
The script just worked partially for me, so I looked in my pi-hole query-log and recognized some yt-adservers that didn't get matched by your RegEx. 
e.g. r2---sn-4g5e6nss.googlevideo.com and r2---sn-uxax4vopj5qx-cxge.googlevideo.com. 
So I tweaked your RegEx to match these also. Since that I have seen way less ads than before. Maybe you could have a look at my new RegEx.

(I hope this is the right procedure to contribute to your project. This is my first time.)